### PR TITLE
Add reprs, a tox.ini, and fix expects version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.egg-info
 build/
 dist/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ before_install: |
   source $HOME/virtualenv/python2.7/bin/activate
 
   # run the build
-  py.test -q && behave -c
+  py.test -q tests && behave -c
   BASH
 
   chmod +x tests.sh

--- a/dockerpty/io.py
+++ b/dockerpty/io.py
@@ -129,6 +129,9 @@ class Stream(object):
                 if e.errno not in Stream.ERRNO_RECOVERABLE:
                     raise e
 
+    def __repr__(self):
+        return "{cls}({fd})".format(cls=type(self).__name__, fd=self.fd)
+
 
 class Demuxer(object):
     """
@@ -207,6 +210,10 @@ class Demuxer(object):
 
         return size
 
+    def __repr__(self):
+        return "{cls}({stream})".format(cls=type(self).__name__,
+                                        stream=self.stream)
+
 
 class Pump(object):
     """
@@ -256,3 +263,9 @@ class Pump(object):
         except OSError as e:
             if e.errno != errno.EPIPE:
                 raise e
+
+    def __repr__(self):
+        return "{cls}(from={from_stream}, to={to_stream})".format(
+            cls=type(self).__name__,
+            from_stream=self.from_stream,
+            to_stream=self.to_stream)

--- a/dockerpty/tty.py
+++ b/dockerpty/tty.py
@@ -122,3 +122,9 @@ class Terminal(object):
                 termios.TCSADRAIN,
                 self.original_attributes,
             )
+
+    def __repr__(self):
+        return "{cls}({fd}, raw={raw})".format(
+            cls=type(self).__name__,
+            fd=self.fd,
+            raw=self.raw)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 docker-py>=0.3.2
 pytest>=2.5.2
 behave>=1.2.4
-expects>=0.2.3
+expects>=0.2.3, < 0.4

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -110,6 +110,11 @@ class TestStream(object):
         stream = io.Stream(StringIO())
         expect(stream.write('')).to.be.none
 
+    def test_repr(self):
+        fd = StringIO()
+        stream = io.Stream(fd)
+        expect(repr(stream)).to.equal("Stream(%s)" % fd)
+
 
 class TestDemuxer(object):
 
@@ -155,6 +160,11 @@ class TestDemuxer(object):
         demuxer.write(u'test')
         expect(s.getvalue()).to.equal('test')
 
+    def test_repr(self):
+        s = StringIO()
+        demuxer = io.Demuxer(s)
+        expect(repr(demuxer)).to.equal("Demuxer(%s)" % s)
+
 
 class TestPump(object):
 
@@ -177,3 +187,9 @@ class TestPump(object):
         b = StringIO()
         pump = io.Pump(a, b)
         expect(pump.flush(3)).to.equal(2)
+
+    def test_repr(self):
+        a = StringIO(u'fo')
+        b = StringIO()
+        pump = io.Pump(a, b)
+        expect(repr(pump)).to.equal("Pump(from=%s, to=%s)" % (a, b))

--- a/tests/unit/test_tty.py
+++ b/tests/unit/test_tty.py
@@ -50,7 +50,6 @@ class TestTerminal(object):
         terminal.start()
         expect(israw(fd)).to.be.true
 
-
     def test_start_when_not_raw(self):
         fd, __ = pty.openpty()
         terminal = tty.Terminal(os.fdopen(fd), raw=False)
@@ -58,14 +57,12 @@ class TestTerminal(object):
         terminal.start()
         expect(israw(fd)).to.be.false
 
-
     def test_stop_when_raw(self):
         fd, __ = pty.openpty()
         terminal = tty.Terminal(os.fdopen(fd), raw=True)
         terminal.start()
         terminal.stop()
         expect(israw(fd)).to.be.false
-
 
     def test_raw_with_block(self):
         fd, __ = pty.openpty()
@@ -76,9 +73,13 @@ class TestTerminal(object):
 
         expect(israw(fd)).to.be.false
 
-
     def test_start_does_not_crash_when_fd_is_not_a_tty(self):
         with tempfile.TemporaryFile() as f:
             terminal = tty.Terminal(f, raw=True)
             terminal.start()
             terminal.stop()
+
+    def test_repr(self):
+        fd = 'some_fd'
+        terminal = tty.Terminal(fd, raw=True)
+        expect(repr(terminal)).to.equal("Terminal(some_fd, raw=True)")

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27, pypy
+
+[testenv]
+deps =
+    -rrequirements-dev.txt
+commands =
+    py.test -v tests/
+    behave


### PR DESCRIPTION
I've found myself having to add these reprs a couple times to debug things so I'd like to add them to cut down on debug time.

When I tried to run the test suite I got a bunch of errors. It looks like expects is non-backwards compatible at 0.4, so I set a max version of it.

Also adding a `tox.ini` to make it easier/faster to setup the virtualenv and develop locally.
