### PR TITLE
Migrated to expects v0.4.x

### DIFF
--- a/features/steps/step_definitions.py
+++ b/features/steps/step_definitions.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from behave import *
-from expects import expect
+from expects import expect, equal, be_true, be_false
 import tests.util as util
 
 import dockerpty
@@ -142,21 +142,21 @@ def step_impl(ctx, num):
 def step_impl(ctx):
     actual = util.read_printable(ctx.pty).splitlines()
     wanted = ctx.text.splitlines()
-    expect(actual[-len(wanted):]).to.equal(wanted)
+    expect(actual[-len(wanted):]).to(equal(wanted))
 
 
 @then('The PTY will be closed cleanly')
 def step_impl(ctx):
-    expect(util.exit_code(ctx.pid, timeout=5)).to.equal(0)
+    expect(util.exit_code(ctx.pid, timeout=5)).to(equal(0))
 
 
 @then('The container will not be running')
 def step_impl(ctx):
     running = util.container_running(ctx.client, ctx.container, duration=2)
-    expect(running).to.be.false
+    expect(running).to(be_false)
 
 
 @then('The container will still be running')
 def step_impl(ctx):
     running = util.container_running(ctx.client, ctx.container, duration=2)
-    expect(running).to.be.true
+    expect(running).to(be_true)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 docker-py>=0.3.2
 pytest>=2.5.2
 behave>=1.2.4
-expects>=0.2.3, < 0.4
+expects>=0.4

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from expects import expect
+from expects import expect, equal, be_none, be_true, be_false
 from io import StringIO
 import dockerpty.io as io
 
@@ -29,53 +29,53 @@ def test_set_blocking_changes_fd_flags():
     with tempfile.TemporaryFile() as f:
         io.set_blocking(f, False)
         flags = fcntl.fcntl(f, fcntl.F_GETFL)
-        expect(flags & os.O_NONBLOCK).to.equal(os.O_NONBLOCK)
+        expect(flags & os.O_NONBLOCK).to(equal(os.O_NONBLOCK))
 
         io.set_blocking(f, True)
         flags = fcntl.fcntl(f, fcntl.F_GETFL)
-        expect(flags & os.O_NONBLOCK).to.equal(0)
+        expect(flags & os.O_NONBLOCK).to(equal(0))
 
 
 def test_set_blocking_returns_previous_state():
     with tempfile.TemporaryFile() as f:
         io.set_blocking(f, True)
-        expect(io.set_blocking(f, False)).to.be.true
+        expect(io.set_blocking(f, False)).to(be_true)
 
         io.set_blocking(f, False)
-        expect(io.set_blocking(f, True)).to.be.false
+        expect(io.set_blocking(f, True)).to(be_false)
 
 
 def test_select_returns_streams_for_reading():
         a, b = socket.socketpair()
         a.send('test')
-        expect(io.select([a, b], timeout=0)).to.equal([b])
+        expect(io.select([a, b], timeout=0)).to(equal([b]))
         b.send('test')
-        expect(io.select([a, b], timeout=0)).to.equal([a, b])
+        expect(io.select([a, b], timeout=0)).to(equal([a, b]))
         b.recv(4)
-        expect(io.select([a, b], timeout=0)).to.equal([a])
+        expect(io.select([a, b], timeout=0)).to(equal([a]))
         a.recv(4)
-        expect(io.select([a, b], timeout=0)).to.equal([])
+        expect(io.select([a, b], timeout=0)).to(equal([]))
 
 
 class TestStream(object):
 
     def test_fileno_delegates_to_file_descriptor(self):
         stream = io.Stream(sys.stdout)
-        expect(stream.fileno()).to.equal(sys.stdout.fileno())
+        expect(stream.fileno()).to(equal(sys.stdout.fileno()))
 
 
     def test_read_from_socket(self):
         a, b = socket.socketpair()
         a.send('test')
         stream = io.Stream(b)
-        expect(stream.read(32)).to.equal('test')
+        expect(stream.read(32)).to(equal('test'))
 
 
     def test_write_to_socket(self):
         a, b = socket.socketpair()
         stream = io.Stream(a)
         stream.write('test')
-        expect(b.recv(32)).to.equal('test')
+        expect(b.recv(32)).to(equal('test'))
 
 
     def test_read_from_file(self):
@@ -83,13 +83,13 @@ class TestStream(object):
             stream = io.Stream(f)
             f.write('test')
             f.seek(0)
-            expect(stream.read(32)).to.equal('test')
+            expect(stream.read(32)).to(equal('test'))
 
 
     def test_read_returns_empty_string_at_eof(self):
         with tempfile.TemporaryFile() as f:
             stream = io.Stream(f)
-            expect(stream.read(32)).to.equal('')
+            expect(stream.read(32)).to(equal(''))
 
 
     def test_write_to_file(self):
@@ -97,23 +97,23 @@ class TestStream(object):
             stream = io.Stream(f)
             stream.write('test')
             f.seek(0)
-            expect(f.read(32)).to.equal('test')
+            expect(f.read(32)).to(equal('test'))
 
 
     def test_write_returns_length_written(self):
         with tempfile.TemporaryFile() as f:
             stream = io.Stream(f)
-            expect(stream.write('test')).to.equal(4)
+            expect(stream.write('test')).to(equal(4))
 
 
     def test_write_returns_none_when_no_data(self):
         stream = io.Stream(StringIO())
-        expect(stream.write('')).to.be.none
+        expect(stream.write('')).to(be_none)
 
     def test_repr(self):
         fd = StringIO()
         stream = io.Stream(fd)
-        expect(repr(stream)).to.equal("Stream(%s)" % fd)
+        expect(repr(stream)).to(equal("Stream(%s)" % fd))
 
 
 class TestDemuxer(object):
@@ -128,49 +128,49 @@ class TestDemuxer(object):
 
     def test_fileno_delegates_to_stream(self):
         demuxer = io.Demuxer(sys.stdout)
-        expect(demuxer.fileno()).to.equal(sys.stdout.fileno())
+        expect(demuxer.fileno()).to(equal(sys.stdout.fileno()))
 
 
     def test_reading_single_chunk(self):
         demuxer = io.Demuxer(self.create_fixture())
-        expect(demuxer.read(32)).to.equal('foo')
+        expect(demuxer.read(32)).to(equal('foo'))
 
 
     def test_reading_multiple_chunks(self):
         demuxer = io.Demuxer(self.create_fixture())
-        expect(demuxer.read(32)).to.equal('foo')
-        expect(demuxer.read(32)).to.equal('d')
+        expect(demuxer.read(32)).to(equal('foo'))
+        expect(demuxer.read(32)).to(equal('d'))
 
 
     def test_reading_partial_chunk(self):
         demuxer = io.Demuxer(self.create_fixture())
-        expect(demuxer.read(2)).to.equal('fo')
+        expect(demuxer.read(2)).to(equal('fo'))
 
 
     def test_reading_overlapping_chunks(self):
         demuxer = io.Demuxer(self.create_fixture())
-        expect(demuxer.read(2)).to.equal('fo')
-        expect(demuxer.read(2)).to.equal('o')
-        expect(demuxer.read(2)).to.equal('d')
+        expect(demuxer.read(2)).to(equal('fo'))
+        expect(demuxer.read(2)).to(equal('o'))
+        expect(demuxer.read(2)).to(equal('d'))
 
 
     def test_write_delegates_to_stream(self):
         s = StringIO()
         demuxer = io.Demuxer(s)
         demuxer.write(u'test')
-        expect(s.getvalue()).to.equal('test')
+        expect(s.getvalue()).to(equal('test'))
 
     def test_repr(self):
         s = StringIO()
         demuxer = io.Demuxer(s)
-        expect(repr(demuxer)).to.equal("Demuxer(%s)" % s)
+        expect(repr(demuxer)).to(equal("Demuxer(%s)" % s))
 
 
 class TestPump(object):
 
     def test_fileno_delegates_to_from_stream(self):
         pump = io.Pump(sys.stdout, sys.stderr)
-        expect(pump.fileno()).to.equal(sys.stdout.fileno())
+        expect(pump.fileno()).to(equal(sys.stdout.fileno()))
 
 
     def test_flush_pipes_data_between_streams(self):
@@ -178,18 +178,18 @@ class TestPump(object):
         b = StringIO()
         pump = io.Pump(a, b)
         pump.flush(3)
-        expect(a.read(1)).to.equal('d')
-        expect(b.getvalue()).to.equal('foo')
+        expect(a.read(1)).to(equal('d'))
+        expect(b.getvalue()).to(equal('foo'))
 
 
     def test_flush_returns_length_written(self):
         a = StringIO(u'fo')
         b = StringIO()
         pump = io.Pump(a, b)
-        expect(pump.flush(3)).to.equal(2)
+        expect(pump.flush(3)).to(equal(2))
 
     def test_repr(self):
         a = StringIO(u'fo')
         b = StringIO()
         pump = io.Pump(a, b)
-        expect(repr(pump)).to.equal("Pump(from=%s, to=%s)" % (a, b))
+        expect(repr(pump)).to(equal("Pump(from=%s, to=%s)" % (a, b)))

--- a/tests/unit/test_tty.py
+++ b/tests/unit/test_tty.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from expects import expect
+from expects import expect, equal, be_none, be_true, be_false
 import dockerpty.tty as tty
 import tests.util as util
 
@@ -31,14 +31,14 @@ def israw(fd):
 
 def test_size_returns_none_for_non_tty():
     with tempfile.TemporaryFile() as t:
-        expect(tty.size(t)).to.be.none
+        expect(tty.size(t)).to(be_none)
 
 
 def test_size_returns_a_tuple_for_a_tty():
     fd, __ = pty.openpty()
     fd = os.fdopen(fd)
     util.set_pty_size(fd, (43, 120))
-    expect(tty.size(fd)).to.equal((43, 120))
+    expect(tty.size(fd)).to(equal((43, 120)))
 
 
 class TestTerminal(object):
@@ -46,32 +46,32 @@ class TestTerminal(object):
     def test_start_when_raw(self):
         fd, __ = pty.openpty()
         terminal = tty.Terminal(os.fdopen(fd), raw=True)
-        expect(israw(fd)).to.be.false
+        expect(israw(fd)).to(be_false)
         terminal.start()
-        expect(israw(fd)).to.be.true
+        expect(israw(fd)).to(be_true)
 
     def test_start_when_not_raw(self):
         fd, __ = pty.openpty()
         terminal = tty.Terminal(os.fdopen(fd), raw=False)
-        expect(israw(fd)).to.be.false
+        expect(israw(fd)).to(be_false)
         terminal.start()
-        expect(israw(fd)).to.be.false
+        expect(israw(fd)).to(be_false)
 
     def test_stop_when_raw(self):
         fd, __ = pty.openpty()
         terminal = tty.Terminal(os.fdopen(fd), raw=True)
         terminal.start()
         terminal.stop()
-        expect(israw(fd)).to.be.false
+        expect(israw(fd)).to(be_false)
 
     def test_raw_with_block(self):
         fd, __ = pty.openpty()
         fd = os.fdopen(fd)
 
         with tty.Terminal(fd, raw=True):
-            expect(israw(fd)).to.be.true
+            expect(israw(fd)).to(be_true)
 
-        expect(israw(fd)).to.be.false
+        expect(israw(fd)).to(be_false)
 
     def test_start_does_not_crash_when_fd_is_not_a_tty(self):
         with tempfile.TemporaryFile() as f:
@@ -82,4 +82,4 @@ class TestTerminal(object):
     def test_repr(self):
         fd = 'some_fd'
         terminal = tty.Terminal(fd, raw=True)
-        expect(repr(terminal)).to.equal("Terminal(some_fd, raw=True)")
+        expect(repr(terminal)).to(equal("Terminal(some_fd, raw=True)"))


### PR DESCRIPTION
Hi @d11wtq!

A few weeks ago I released expects 0.4 that introduced some backwards incompatible syntax changes: http://expects.readthedocs.org/en/v0.4.2/changes.html#ago-15-2014

I found that your project were using it and thought I could help with the migration. Hope you like it!

I'm looking for your feedback :smile: 
