### PR TITLE
Fix test failure on master due to race when resizing frequently

### DIFF
--- a/features/interactive_terminal.feature
+++ b/features/interactive_terminal.feature
@@ -107,7 +107,6 @@ Feature: Attaching to an interactive terminal in a docker container
     And I resize the terminal to 30 x 98
     And I resize the terminal to 28 x 98
     And I resize the terminal to 28 x 105
-    And I wait 3 seconds
     And I type "stty size"
     And I press ENTER
     Then I will see the output

--- a/features/steps/step_definitions.py
+++ b/features/steps/step_definitions.py
@@ -107,6 +107,7 @@ def step_impl(ctx, rows, cols):
         ctx.pty,
         (ctx.rows, ctx.cols)
     )
+    time.sleep(0.2)
     os.kill(ctx.pid, signal.SIGWINCH)
 
 
@@ -130,12 +131,6 @@ def step_impl(ctx, key):
         "c-q":   "\x11",
     }
     util.write(ctx.pty, mappings[key.lower()])
-
-
-@when('I wait {num} second')
-@when('I wait {num} seconds')
-def step_impl(ctx, num):
-    time.sleep(int(num))
 
 
 @then('I will see the output')


### PR DESCRIPTION
Resolves #11 

Adding just a bit of delay before sending the `SIGWINCH` fixes this on my desktop. Let's see what the travis build says.
