### PR TITLE
Fix flags variable being set

### DIFF
--- a/dockerpty/pty.py
+++ b/dockerpty/pty.py
@@ -139,8 +139,9 @@ class PseudoTerminal(object):
         if not self.container_info()['State']['Running']:
             self.client.start(self.container, **kwargs)
 
+        flags = [io.set_blocking(p, False) for p in pumps]
+
         try:
-            flags = [io.set_blocking(p, False) for p in pumps]
             with WINCHHandler(self):
                 self._hijack_tty(pumps)
         finally:


### PR DESCRIPTION
If an exception is raised, this is thrown:

UnboundLocalError: local variable 'flags' referenced before assignment
