### PR TITLE
Revert change to wait on all pumps

### DIFF
--- a/dockerpty/pty.py
+++ b/dockerpty/pty.py
@@ -226,9 +226,9 @@ class PseudoTerminal(object):
         with tty.Terminal(sys.stdin, raw=self.israw()):
             self.resize()
             while True:
-                _ready = io.select(pumps, timeout=60)
+                ready = io.select(pumps, timeout=60)
                 try:
-                    if all([p.flush() is None for p in pumps]):
+                    if all([p.flush() is None for p in ready]):
                         break
                 except SSLError as e:
                     if 'The operation did not complete' not in e.strerror:


### PR DESCRIPTION
This reverts commit 8be0c14c9db7aeb63f154ad0e37b781dd05127b5.
And should resolve docker/fig/issues/561

Waiting on all pumps causes dockerpty to basically shutdown after 60 seconds of inactivity, and never fully resolved the jenkins issue in #4

cc @aanand @bfirsh 
