### PR TITLE
Fix flush logic - take 2

### DIFF
--- a/dockerpty/pty.py
+++ b/dockerpty/pty.py
@@ -228,7 +228,7 @@ class PseudoTerminal(object):
             while True:
                 ready = io.select(pumps, timeout=60)
                 try:
-                    if all([p.flush() is None for p in ready]):
+                    if any([p.flush() is None for p in ready]):
                         break
                 except SSLError as e:
                     if 'The operation did not complete' not in e.strerror:


### PR DESCRIPTION
Fix for docker/fig/pull/561

I guess the timeout was masking this being broken.  
