### PR TITLE
Jenkins support - don't select stdin when interactive=False

### DIFF
--- a/dockerpty/__init__.py
+++ b/dockerpty/__init__.py
@@ -17,11 +17,11 @@
 from dockerpty.pty import PseudoTerminal
 
 
-def start(client, container):
+def start(client, container, interactive=True):
     """
     Present the PTY of the container inside the current process.
 
     This is just a wrapper for PseudoTerminal(client, container).start()
     """
 
-    PseudoTerminal(client, container).start()
+    PseudoTerminal(client, container, interactive=interactive).start()

--- a/dockerpty/pty.py
+++ b/dockerpty/pty.py
@@ -109,7 +109,7 @@ class PseudoTerminal(object):
     """
 
 
-    def __init__(self, client, container):
+    def __init__(self, client, container, interactive=True):
         """
         Initialize the PTY using the docker.Client instance and container dict.
         """
@@ -117,6 +117,7 @@ class PseudoTerminal(object):
         self.client = client
         self.container = container
         self.raw = None
+        self.interactive = interactive
 
 
     def start(self, **kwargs):
@@ -129,11 +130,14 @@ class PseudoTerminal(object):
 
         pty_stdin, pty_stdout, pty_stderr = self.sockets()
 
+
         mappings = [
-            (io.Stream(sys.stdin), pty_stdin),
             (pty_stdout, io.Stream(sys.stdout)),
             (pty_stderr, io.Stream(sys.stderr)),
         ]
+
+        if self.interactive:
+            mappings.insert(0, (io.Stream(sys.stdin), pty_stdin))
 
         pumps = [io.Pump(a, b) for (a, b) in mappings if a and b]
 


### PR DESCRIPTION
Resolves #4 

(includes the branch in #23, which will need to get merged first anyway)

Requires one change to fig as well:

``` diff
diff --git a/fig/cli/main.py b/fig/cli/main.py
index 2cb7d02..2c35980 100644
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -7,7 +7,7 @@ import signal
 from operator import attrgetter

 from inspect import getdoc
-from fig.packages import dockerpty
+import dockerpty

 from .. import __version__
 from ..project import NoSuchService, ConfigurationError
@@ -337,7 +337,7 @@ class TopLevelCommand(Command):
             print(container.name)
         else:
             service.start_container(container, ports=None, one_off=True)
-            dockerpty.start(project.client, container.id)
+            dockerpty.start(project.client, container.id, interactive=not options['-T'])
             exit_code = container.wait()
             if options['--rm']:
                 log.info("Removing %s..." % container.name)
```
