### PR TITLE
SSL error

### DIFF
--- a/dockerpty/io.py
+++ b/dockerpty/io.py
@@ -207,6 +207,8 @@ class Demuxer(object):
                 while True:
                     try:
                         nxt = self.stream.read(size - len(data))
+                        if nxt is None:
+                            continue
                         break
                     except ssl.SSLError as e:
                         if e.errno != 2:
@@ -238,6 +240,8 @@ class Demuxer(object):
                 while True:
                     try:
                         nxt = self.stream.read(8 - len(data))
+                        if nxt is None:
+                            continue
                         break
                     except ssl.SSLError as e:
                         if e.errno != 2:

--- a/dockerpty/io.py
+++ b/dockerpty/io.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+import ssl
 import fcntl
 import errno
 import struct
@@ -203,7 +204,13 @@ class Demuxer(object):
         else:
             data = ''
             while len(data) < size:
-                nxt = self.stream.read(size - len(data))
+                while True:
+                    try:
+                        nxt = self.stream.read(size - len(data))
+                        break
+                    except ssl.SSLError as e:
+                        if e.errno != 2:
+                            raise
                 if not nxt:
                     # the stream has closed, return what data we got
                     return data
@@ -228,7 +235,13 @@ class Demuxer(object):
         else:
             data = ''
             while len(data) < 8:
-                nxt = self.stream.read(8 - len(data))
+                while True:
+                    try:
+                        nxt = self.stream.read(8 - len(data))
+                        break
+                    except ssl.SSLError as e:
+                        if e.errno != 2:
+                            raise
                 if not nxt:
                     # The stream has closed, there's nothing more to read
                     return 0

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -124,7 +124,10 @@ class SlowStream(object):
         if len(self.chunks) == 0:
             return ''
         else:
-            if len(self.chunks[0]) <= n:
+            if self.chunks[0] is None:
+                chunk = self.chunks[0]
+                self.chunks = self.chunks[1:]
+            elif len(self.chunks[0]) <= n:
                 chunk = self.chunks[0]
                 self.chunks = self.chunks[1:]
             else:
@@ -175,6 +178,7 @@ class TestDemuxer(object):
         slow_stream = SlowStream([
             "\x01\x00\x00\x00",
             "\x00\x00\x00\x03foo",
+            None,
             "\x01\x00",
             "\x00\x00\x00\x00\x00\x01d",
         ])


### PR DESCRIPTION
With docker 1.4.1 I'm seeing a behavior when I run a non-interactive container where ssl complains it can't complete a request to read from the stream. This error means that the multiplexing goes out of place and the output becomes wrong.

To fix this, it seems we just need to retry reading again and all is good.

This branch also includes a fix to travis.ci
It looked like the "before_install" wasn't running and so I've moved out the files that were created in it and just made all those commands part of the "install" block.
