### PR TITLE
dockerpty.start is missing a generic **kwargs

### DIFF
--- a/dockerpty/__init__.py
+++ b/dockerpty/__init__.py
@@ -17,11 +17,11 @@
 from dockerpty.pty import PseudoTerminal
 
 
-def start(client, container, interactive=True):
+def start(client, container, interactive=True, **kwargs):
     """
     Present the PTY of the container inside the current process.
 
     This is just a wrapper for PseudoTerminal(client, container).start()
     """
 
-    PseudoTerminal(client, container, interactive=interactive).start()
+    PseudoTerminal(client, container, interactive=interactive).start(**kwargs)


### PR DESCRIPTION
dockerpty.start(..) is missing a **kwargs so other argument can be given to the client.start(...). PseudoTerminal.start() already have a generic **kwargs, so nothing to change there