### PR TITLE
Add the ability to specify where stdout, stderr and stdin are

### DIFF
--- a/dockerpty/__init__.py
+++ b/dockerpty/__init__.py
@@ -17,11 +17,11 @@
 from dockerpty.pty import PseudoTerminal
 
 
-def start(client, container, interactive=True):
+def start(client, container, interactive=True, stdout=None, stderr=None, stdin=None):
     """
     Present the PTY of the container inside the current process.
 
     This is just a wrapper for PseudoTerminal(client, container).start()
     """
 
-    PseudoTerminal(client, container, interactive=interactive).start()
+    PseudoTerminal(client, container, interactive=interactive, stdout=stdout, stderr=stderr, stdin=stdin).start()


### PR DESCRIPTION
I finally started adding functional tests to my docker client Harpoon and realised that dockerpty's behaviour of closing the streams doesn't work too well with nosetests stdout/stderr proxies.

Being able to say where dockerpty should write to would be very helpful to me :)