### PR TITLE
Support running tests ('behave features/') on OS X.

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -14,15 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import docker
-
+from docker.utils import kwargs_from_env
 
 def before_all(ctx):
     """
     Pulls down busybox:latest before anything is tested.
     """
 
-    ctx.client = docker.Client(version='1.15')
+    if sys.platform.startswith('darwin') or sys.platform.startswith('win32'):
+        kwargs = kwargs_from_env()
+        # Hack borrowed from here:
+        # http://docker-py.readthedocs.org/en/latest/boot2docker/
+        # See also: https://github.com/docker/docker-py/issues/406
+        kwargs['tls'].assert_hostname = False
+        kwargs['version'] = '1.15'
+        ctx.client = docker.Client(**kwargs)
+    else:
+        ctx.client = docker.Client(version='1.15')
     ctx.client.pull('busybox:latest')
 
 

--- a/features/steps/step_definitions.py
+++ b/features/steps/step_definitions.py
@@ -89,7 +89,12 @@ def step_impl(ctx):
         else:
             os._exit(0)
     else:
-        tty = os.ttyname(fd)
+        try:
+            tty = os.ttyname(fd)
+        except OSError as ex:
+            # Not supported on OS X. But since we're not using this
+            # TTY name anyway, let the test pass.
+            tty = 'OSX'
         ctx.pty = fd
         util.set_pty_size(
             ctx.pty,


### PR DESCRIPTION
Right now, 'behave features/' command fails on OS X with boot2docker. This is because docker-py client has to be created differently on that OS, and additionally, os.ttyname will not work.

Since dockerpty itself works on OS X (with slight changes to test code snippet, as shown below), it would be nice if tests worked too.

Great project!

Code snippet:

```
import docker
import dockerpty
from docker.utils import kwargs_from_env

kwargs = kwargs_from_env()
kwargs['tls'].assert_hostname = False

client = docker.AutoVersionClient(**kwargs)
container = client.create_container(
    image='busybox:latest',
    stdin_open=True,
    tty=True,
    command='/bin/sh',
)

dockerpty.start(client, container)
```