### PR TITLE
Stop system stdout/stderr being closed

### DIFF
--- a/dockerpty/io.py
+++ b/dockerpty/io.py
@@ -323,7 +323,11 @@ class Pump(object):
     Pumps are selectable based on the 'read' end of the pipe.
     """
 
-    def __init__(self, from_stream, to_stream, wait_for_output=True):
+    def __init__(self,
+                 from_stream,
+                 to_stream,
+                 wait_for_output=True,
+                 propagate_close=True):
         """
         Initialize a Pump with a Stream to read from and another to write to.
 
@@ -335,6 +339,7 @@ class Pump(object):
         self.to_stream = to_stream
         self.eof = False
         self.wait_for_output = wait_for_output
+        self.propagate_close = propagate_close
 
     def fileno(self):
         """
@@ -363,7 +368,8 @@ class Pump(object):
 
             if read is None or len(read) == 0:
                 self.eof = True
-                self.to_stream.close()
+                if self.propagate_close:
+                    self.to_stream.close()
                 return None
 
             return self.to_stream.write(read)

--- a/dockerpty/pty.py
+++ b/dockerpty/pty.py
@@ -132,17 +132,16 @@ class PseudoTerminal(object):
         """
 
         pty_stdin, pty_stdout, pty_stderr = self.sockets()
+        pumps = []
 
+        if pty_stdin and self.interactive:
+            pumps.append(io.Pump(io.Stream(self.stdin), pty_stdin, wait_for_output=False))
 
-        mappings = [
-            (pty_stdout, io.Stream(self.stdout), True),
-            (pty_stderr, io.Stream(self.stderr), True),
-        ]
+        if pty_stdout:
+            pumps.append(io.Pump(pty_stdout, io.Stream(self.stdout)))
 
-        if self.interactive:
-            mappings.insert(0, (io.Stream(self.stdin), pty_stdin, False))
-
-        pumps = [io.Pump(a, b, c) for (a, b, c) in mappings if a and b]
+        if pty_stderr:
+            pumps.append(io.Pump(pty_stderr, io.Stream(self.stderr)))
 
         if not self.container_info()['State']['Running']:
             self.client.start(self.container, **kwargs)

--- a/dockerpty/pty.py
+++ b/dockerpty/pty.py
@@ -138,10 +138,10 @@ class PseudoTerminal(object):
             pumps.append(io.Pump(io.Stream(self.stdin), pty_stdin, wait_for_output=False))
 
         if pty_stdout:
-            pumps.append(io.Pump(pty_stdout, io.Stream(self.stdout)))
+            pumps.append(io.Pump(pty_stdout, io.Stream(self.stdout), propagate_close=False))
 
         if pty_stderr:
-            pumps.append(io.Pump(pty_stderr, io.Stream(self.stderr)))
+            pumps.append(io.Pump(pty_stderr, io.Stream(self.stderr), propagate_close=False))
 
         if not self.container_info()['State']['Running']:
             self.client.start(self.container, **kwargs)


### PR DESCRIPTION
As reported in https://github.com/d11wtq/dockerpty/pull/36#issuecomment-100632605, we're now closing the system stdout/stderr when the container's counterparts close. This isn't always what the user wants - we should leave it to them to close the streams or not.

Closes #41.

Should fix https://github.com/docker/compose/issues/1424 and https://github.com/docker/compose/issues/1483 once a release is out.