### PR TITLE
Pass extra kwargs to start

### DIFF
--- a/dockerpty/__init__.py
+++ b/dockerpty/__init__.py
@@ -17,11 +17,11 @@
 from dockerpty.pty import PseudoTerminal
 
 
-def start(client, container, interactive=True, stdout=None, stderr=None, stdin=None):
+def start(client, container, interactive=True, stdout=None, stderr=None, stdin=None, **start_kwargs):
     """
     Present the PTY of the container inside the current process.
 
     This is just a wrapper for PseudoTerminal(client, container).start()
     """
 
-    PseudoTerminal(client, container, interactive=interactive, stdout=stdout, stderr=stderr, stdin=stdin).start()
+    PseudoTerminal(client, container, interactive=interactive, stdout=stdout, stderr=stderr, stdin=stdin).start(**start_kwargs)


### PR DESCRIPTION
Hello,

I just wanna propose this change so that you can have a say in how the client starts the container if you're using the shortcut dockerpty.start function.

Thanks.
