### PR TITLE
Fix concurrency/SSL issues in features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       env: REQUIREMENTS=requirements-dev.txt VENV=pypy
       services:
         - docker
-    - python: "3.3"
+    - python: "3.4"
       env: REQUIREMENTS=requirements3-dev.txt VENV=python3.3
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ matrix:
         - docker
 
 install: pip install -r $REQUIREMENTS
-script: py.test -q tests && behave -c
+script: py.test -q tests && behave -c --no-capture -q

--- a/dockerpty/__init__.py
+++ b/dockerpty/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dockerpty.pty import PseudoTerminal, RunOperation
+from dockerpty.pty import PseudoTerminal, RunOperation, ExecOperation, exec_create
 
 
 def start(client, container, interactive=True, stdout=None, stderr=None, stdin=None, logs=None):
@@ -27,4 +27,24 @@ def start(client, container, interactive=True, stdout=None, stderr=None, stdin=N
     operation = RunOperation(client, container, interactive=interactive, stdout=stdout,
                              stderr=stderr, stdin=stdin, logs=logs)
 
+    PseudoTerminal(client, operation).start()
+
+
+def exec_command(
+        client, container, command, interactive=True, stdout=None, stderr=None, stdin=None):
+    """
+    Run provided command via exec API in provided container.
+
+    This is just a wrapper for PseudoTerminal(client, container).exec_command()
+    """
+    exec_id = exec_create(client, container, command, interactive=interactive)
+
+    operation = ExecOperation(client, exec_id,
+                              interactive=interactive, stdout=stdout, stderr=stderr, stdin=stdin)
+    PseudoTerminal(client, operation).start()
+
+
+def start_exec(client, exec_id, interactive=True, stdout=None, stderr=None, stdin=None):
+    operation = ExecOperation(client, exec_id,
+                              interactive=interactive, stdout=stdout, stderr=stderr, stdin=stdin)
     PseudoTerminal(client, operation).start()

--- a/dockerpty/__init__.py
+++ b/dockerpty/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dockerpty.pty import PseudoTerminal
+from dockerpty.pty import PseudoTerminal, RunOperation
 
 
 def start(client, container, interactive=True, stdout=None, stderr=None, stdin=None, logs=None):
@@ -24,4 +24,7 @@ def start(client, container, interactive=True, stdout=None, stderr=None, stdin=N
     This is just a wrapper for PseudoTerminal(client, container).start()
     """
 
-    PseudoTerminal(client, container, interactive=interactive, stdout=stdout, stderr=stderr, stdin=stdin, logs=logs).start()
+    operation = RunOperation(client, container, interactive=interactive, stdout=stdout,
+                             stderr=stderr, stdin=stdin, logs=logs)
+
+    PseudoTerminal(client, operation).start()

--- a/features/environment.py
+++ b/features/environment.py
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import docker
-from docker.utils import kwargs_from_env
 from docker.errors import NotFound
+
+from utils import get_client
 
 
 IMAGE = "busybox:latest"
@@ -27,8 +27,7 @@ def before_all(ctx):
     Pulls down busybox:latest before anything is tested.
     """
 
-    kwargs = kwargs_from_env(assert_hostname=False)
-    ctx.client = docker.AutoVersionClient(**kwargs)
+    ctx.client = get_client()
     try:
         ctx.client.inspect_image(IMAGE)
     except NotFound:

--- a/features/environment.py
+++ b/features/environment.py
@@ -16,6 +16,11 @@
 
 import docker
 from docker.utils import kwargs_from_env
+from docker.errors import NotFound
+
+
+IMAGE = "busybox:latest"
+
 
 def before_all(ctx):
     """
@@ -24,7 +29,10 @@ def before_all(ctx):
 
     kwargs = kwargs_from_env(assert_hostname=False)
     ctx.client = docker.AutoVersionClient(**kwargs)
-    ctx.client.pull('busybox:latest')
+    try:
+        ctx.client.inspect_image(IMAGE)
+    except NotFound:
+        ctx.client.pull(IMAGE)
 
 
 def after_scenario(ctx, scenario):

--- a/features/exec_interactive_stdin.feature
+++ b/features/exec_interactive_stdin.feature
@@ -1,0 +1,81 @@
+# dockerpty: exec_interactive_stdin.feature.
+#
+# Copyright 2014 Chris Corbyn <chris@w3style.co.uk>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+Feature: Executing command in a running docker container
+  As a user I want to be able to execute a command in a running docker.
+
+
+  Scenario: Capturing output
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    When I exec "sh -c 'ls -1 / | tail -n 3'" in a running docker container
+    Then I will see the output
+      """
+      tmp
+      usr
+      var
+      """
+
+
+  Scenario: Sending input
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    When I exec "/bin/cat" in a running docker container with a PTY
+    And I type "Hello World!"
+    And I press ENTER
+    Then I will see the output
+      """
+      Hello World!
+      Hello World!
+      """
+
+
+  Scenario: Capturing errors
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    When I exec "sh -c 'cat | sh'" in a running docker container with a PTY
+    And I type "echo 'Hello World!' 1>&2"
+    And I press ENTER
+    Then I will see the output
+      """
+      echo 'Hello World!' 1>&2
+      Hello World!
+      """
+
+
+  Scenario: Capturing mixed output and errors
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    When I exec "sh -c 'cat | sh'" in a running docker container with a PTY
+    And I type "echo 'Hello World!'"
+    And I press ENTER
+    Then I will see the output
+      """
+      echo 'Hello World!'
+      Hello World!
+      """
+    When I type "echo 'Hello Universe!' 1>&2"
+    And I press ENTER
+    Then I will see the output
+      """
+      echo 'Hello Universe!' 1>&2
+      Hello Universe!
+      """

--- a/features/exec_interactive_terminal.feature
+++ b/features/exec_interactive_terminal.feature
@@ -1,0 +1,175 @@
+# dockerpty: exec_interactive_terminal.feature.
+#
+# Copyright 2014 Chris Corbyn <chris@w3style.co.uk>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+Feature: Attaching to an interactive terminal in a docker container
+  As a user I want to be able to spawn a shell in a running docker
+  container, attach to it and control the shell inside my own terminal.
+
+
+  Scenario: Starting the PTY
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    And I exec "/bin/sh" in a docker container with a PTY
+    When I start exec with a PTY
+    Then I will see the output
+      """
+      / #
+      """
+
+
+  Scenario: Controlling input
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    And I exec "/bin/sh" in a docker container with a PTY
+    When I start exec with a PTY
+    And I type "whoami"
+    Then I will see the output
+      """
+      / # whoami
+      """
+
+
+  Scenario: Controlling standard output
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    And I exec "/bin/sh" in a docker container with a PTY
+    When I start exec with a PTY
+    And I type "uname"
+    And I press ENTER
+    Then I will see the output
+      """
+      / # uname
+      Linux
+      / #
+      """
+
+
+  Scenario: Controlling standard error
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    And I exec "/bin/sh" in a docker container with a PTY
+    When I start exec with a PTY
+    And I type "ls blah"
+    And I press ENTER
+    Then I will see the output
+      """
+      / # ls blah
+      ls: blah: No such file or directory
+      / #
+      """
+
+
+  Scenario: Initializing the PTY with the correct size
+    Given I am using a TTY with dimensions 20 x 70
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    And I exec "/bin/sh" in a docker container with a PTY
+    When I start exec with a PTY
+    And I type "stty size"
+    And I press ENTER
+    Then I will see the output
+      """
+      / # stty size
+      20 70
+      / #
+      """
+
+
+  Scenario: Resizing the PTY
+    Given I am using a TTY with dimensions 20 x 70
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    And I exec "/bin/sh" in a docker container with a PTY
+    When I start exec with a PTY
+    And I resize the terminal to 30 x 100
+    And I type "stty size"
+    And I press ENTER
+    Then I will see the output
+      """
+      / # stty size
+      30 100
+      / #
+      """
+
+
+  Scenario: Resizing the PTY frenetically
+    Given I am using a TTY with dimensions 20 x 70
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    And I exec "/bin/sh" in a docker container with a PTY
+    When I start exec with a PTY
+    And I resize the terminal to 30 x 100
+    And I resize the terminal to 30 x 101
+    And I resize the terminal to 30 x 98
+    And I resize the terminal to 28 x 98
+    And I resize the terminal to 28 x 105
+    And I type "stty size"
+    And I press ENTER
+    Then I will see the output
+      """
+      / # stty size
+      28 105
+      / #
+      """
+
+
+  Scenario: Terminating the PTY
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    And I exec "/bin/sh" in a docker container with a PTY
+    When I start exec with a PTY
+    And I type "exit"
+    And I press ENTER
+    Then The PTY will be closed cleanly
+
+
+  Scenario: Detaching from the PTY
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    And I exec "/bin/sh" in a docker container with a PTY
+    When I start exec with a PTY
+    And I press ENTER
+    And I press C-p
+    And I press C-q
+    Then The PTY will be closed cleanly
+
+
+  Scenario: Cleanly exiting on race conditions
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    And I exec "/bin/true" in a docker container with a PTY
+    When I start exec with a PTY
+    Then The PTY will be closed cleanly
+
+
+  Scenario: Running when the container is started
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    When I exec "/bin/sh" in a running docker container with a PTY
+    And I press ENTER
+    Then I will see the output
+      """
+      / #
+      """

--- a/features/exec_non_interactive.feature
+++ b/features/exec_non_interactive.feature
@@ -1,0 +1,55 @@
+# dockerpty: exec_non_interactive.feature.
+#
+# Copyright 2014 Chris Corbyn <chris@w3style.co.uk>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+Feature: Executing command in a running docker container non-interactively
+  As a user I want to be able to execute a command in a running docker
+  container and view its output in my own terminal.
+
+
+  Scenario: Capturing output
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    When I exec "/bin/tail -f -n1 /etc/passwd" in a running docker container
+    Then I will see the output
+      """
+      nobody:x:99:99:nobody:/home:/bin/false
+      """
+
+
+  Scenario: Capturing errors
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    When I exec "sh -c 'tail -f -n1 /etc/passwd 1>&2'" in a running docker container
+    Then I will see the output
+      """
+      nobody:x:99:99:nobody:/home:/bin/false
+      """
+
+
+  Scenario: Ignoring input
+    Given I am using a TTY
+    And I run "cat" in a docker container with stdin open
+    And I start the container
+    When I exec "/bin/tail -f -n1 /etc/passwd" in a running docker container
+    And I press ENTER
+    Then I will see the output
+      """
+      nobody:x:99:99:nobody:/home:/bin/false
+      """
+    And The container will still be running

--- a/features/steps/step_definitions.py
+++ b/features/steps/step_definitions.py
@@ -24,7 +24,39 @@ import sys
 import os
 import signal
 import time
-import six
+
+
+def alloc_pty(ctx, f, *args, **kwargs):
+    pid, fd = pty.fork()
+
+    if pid == pty.CHILD:
+        tty = os.ttyname(0)
+
+        sys.stdin = open(tty, 'r')
+        sys.stdout = open(tty, 'w')
+        sys.stderr = open(tty, 'w')
+
+        # alternative way of doing ^ is to do:
+        # kwargs["stdout"] = open(tty, 'w')
+        # kwargs["stderr"] = open(tty, 'w')
+        # kwargs["stdin"] = open(tty, 'r')
+
+        f(*args, **kwargs)
+        sys.exit(0)
+    else:
+        ctx.pty = fd
+        util.set_pty_size(
+            ctx.pty,
+            (ctx.rows, ctx.cols)
+        )
+        ctx.pid = pid
+        util.wait(ctx.pty, timeout=5)
+    time.sleep(1)  # give the terminal some time to print prompt
+
+    # util.exit_code can be called only once
+    ctx.exit_code = util.exit_code(ctx.pid, timeout=5)
+    if ctx.exit_code != 0:
+        raise Exception("child process did not finish correctly")
 
 
 @given('I am using a TTY')
@@ -57,9 +89,10 @@ def step_impl(ctx, cmd):
         stdin_open=True,
         tty=True,
         host_config={"LogConfig": {
-            "Type": "none"
+            "Type": "none"  # there is not "none" driver on 1.8
         }}
     )
+
 
 @given('I run "{cmd}" in a docker container')
 def step_impl(ctx, cmd):
@@ -67,6 +100,11 @@ def step_impl(ctx, cmd):
         image='busybox:latest',
         command=cmd,
     )
+
+
+@given('I exec "{cmd}" in a docker container with a PTY')
+def step_impl(ctx, cmd):
+    ctx.exec_id = dockerpty.exec_create(ctx.client, ctx.container, cmd, interactive=True)
 
 
 @given('I run "{cmd}" in a docker container with stdin open')
@@ -78,6 +116,11 @@ def step_impl(ctx, cmd):
     )
 
 
+@given('I start the container')
+def step_impl(ctx):
+    ctx.client.start(ctx.container)
+
+
 @when('I start the container')
 def step_impl(ctx):
     ctx.client.start(ctx.container)
@@ -85,30 +128,27 @@ def step_impl(ctx):
 
 @when('I start dockerpty')
 def step_impl(ctx):
-    pid, fd = pty.fork()
+    alloc_pty(ctx, dockerpty.start, ctx.client, ctx.container, logs=0)
 
-    if pid == pty.CHILD:
-        tty = os.ttyname(0)
-        sys.stdin = open(tty, 'r')
-        sys.stdout = open(tty, 'w')
-        sys.stderr = open(tty, 'w')
 
-        try:
-            dockerpty.start(ctx.client, ctx.container, logs=0)
-        except Exception as e:
-            raise e
-            os._exit(1)
-        else:
-            os._exit(0)
-    else:
-        ctx.pty = fd
-        util.set_pty_size(
-            ctx.pty,
-            (ctx.rows, ctx.cols)
-        )
-        ctx.pid = pid
-        util.wait(ctx.pty, timeout=5)
-    time.sleep(1) # give the terminal some time to print prompt
+@when('I exec "{cmd}" in a running docker container')
+def step_impl(ctx, cmd):
+    alloc_pty(ctx, dockerpty.exec_command, ctx.client, ctx.container, cmd, interactive=False)
+
+
+@when('I exec "{cmd}" in a running docker container with a PTY')
+def step_impl(ctx, cmd):
+    alloc_pty(ctx, dockerpty.exec_command, ctx.client, ctx.container, cmd, interactive=True)
+
+
+@when('I start exec')
+def step_impl(ctx):
+    alloc_pty(ctx, dockerpty.start_exec, ctx.client, ctx.exec_id, interactive=False)
+
+
+@when('I start exec with a PTY')
+def step_impl(ctx):
+    alloc_pty(ctx, dockerpty.start_exec, ctx.client, ctx.exec_id, interactive=True)
 
 
 @when('I resize the terminal to {rows} x {cols}')
@@ -119,13 +159,14 @@ def step_impl(ctx, rows, cols):
         ctx.pty,
         (ctx.rows, ctx.cols)
     )
-    time.sleep(0.2)
+    time.sleep(1)
     os.kill(ctx.pid, signal.SIGWINCH)
 
 
 @when('I type "{text}"')
 def step_impl(ctx, text):
     util.write(ctx.pty, text.encode())
+
 
 @when('I press {key}')
 def step_impl(ctx, key):
@@ -146,6 +187,7 @@ def step_impl(ctx, key):
 
 @then('I will see the output')
 def step_impl(ctx):
+    # you should check `actual` when tests fail
     actual = util.read_printable(ctx.pty).splitlines()
     wanted = ctx.text.splitlines()
     expect(actual[-len(wanted):]).to(equal(wanted))
@@ -153,7 +195,9 @@ def step_impl(ctx):
 
 @then('The PTY will be closed cleanly')
 def step_impl(ctx):
-    expect(util.exit_code(ctx.pid, timeout=5)).to(equal(0))
+    if not hasattr(ctx, "exit_code"):
+        ctx.exit_code = util.exit_code(ctx.pid, timeout=5)
+    expect(ctx.exit_code).to(equal(0))
 
 
 @then('The container will not be running')

--- a/features/utils.py
+++ b/features/utils.py
@@ -1,0 +1,7 @@
+import docker
+from docker.utils import kwargs_from_env
+
+
+def get_client():
+    kwargs = kwargs_from_env(assert_hostname=False)
+    return docker.AutoVersionClient(**kwargs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-docker-py>=0.3.2
+docker-py>=1.7.0rc2
 pytest>=2.5.2
 behave>=1.2.4
 expects>=0.4

--- a/requirements3-dev.txt
+++ b/requirements3-dev.txt
@@ -1,4 +1,4 @@
-docker-py>=0.7.1
+docker-py>=1.7.0rc2
 pytest>=2.5.2
 behave>=1.2.4
 expects>=0.4


### PR DESCRIPTION
Will rebase once #48 is in.

Re-using the `docker.Client` object in both the parent and child process causes weird SSL errors and read timeouts, so create a separate one in the child.
