### PR TITLE
Add .cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.egg-info
 build/
 dist/
+.cache/
 .tox/


### PR DESCRIPTION
It's created by `py.test`, though I'm not sure how or why.