### PR TITLE
Update readme to work with newest Docker library

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install dockerpty
 
 Dependencies:
 
-  * docker-py>=0.3.2
+  * docker>=4
 
 However, this library does not explicitly declare this dependency in PyPi for a
 number of reasons. It is assumed you have it installed.
@@ -32,7 +32,7 @@ This obviously only works when run in a terminal.
 import docker
 import dockerpty
 
-client = docker.Client()
+client = docker.APIClient()
 container = client.create_container(
     image='busybox:latest',
     stdin_open=True,


### PR DESCRIPTION
When docker ditched the `docker-py` library in favor of `docker` on PyPI they made a few very very small changes that break this library.

I've gone ahead and upgraded the readme to work with these new changes. I should point out that these changes are trivial- it basically amounts to changing `docker.client()` to `docker.APIClient()`. That's because the "low level API" that this project is based on has moved- but it is still there, and completely compatible with this library. Literally all anyone has to do in order to use the latest docker python library is change that one call so they get the low level client instead of the high level one.

resolves #78 
resolves #79 